### PR TITLE
フォルダ削除機能の実装

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -27,4 +27,16 @@ class FolderController extends Controller
         'id' => $folder->id,
     ]);
     }
+
+    #フォルダの削除
+    public function destroy($id)
+    {
+    #削除処理
+    $folder = Folder::findOrFail($id);
+    $folder->delete();
+
+    return redirect('/')->with('flash_message', 'Post Deleted!');
+    
+    }
+    
 }

--- a/database/migrations/2020_03_26_105738_change_tasks_table.php
+++ b/database/migrations/2020_03_26_105738_change_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign(['folder_id']);
+            $table->foreign('folder_id')->references('id')->on('folders')->onDelete('cascade');
+
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -20,9 +20,15 @@
             @foreach($folders as $folder)
               <a href="{{ route('tasks.index', ['id' => $folder->id]) }}" class="main-folder-add {{ $current_folder_id === $folder->id ? 'active' : '' }}">
                 <p class="main-folder-add-title  ">{{ $folder->title }}</p>
-                <i class="far fa-trash-alt"></i>
-                <i class="fas fa-cog"></i>
               </a>
+              <form action="{{ action('FolderController@destroy', $folder->id) }}" id="form_{{ $folder->id }}" method="post" style="display:inline">
+                {{ csrf_field() }}
+                {{ method_field('delete') }}
+                <a href="#" data-id="{{ $folder->id }}" onclick="deletePost(this);" class="fs12">
+                  <i class="far fa-trash-alt"></i>
+                </a>
+              </form>
+              <i class="fas fa-cog"></i>
             @endforeach
           </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ Route::group(['middleware' => 'auth'], function() {
         Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
 
     });
+
+    Route::delete('/folders/{folder}', 'FolderController@destroy');
     Route::delete('/folders/{folder}/tasks', 'TaskController@destroy');
 });
 


### PR DESCRIPTION
・フォルダの削除機能を実装した。
タスクの外部キー制約を変更し、親であるフォルダが削除された場合に子供であるタスクが全て削除されるように実装
・view側は仮設置